### PR TITLE
actions-rs/tarpauliinを剥がす

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -157,10 +157,13 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@cargo-binstall
+      - name: Install cargo-tarpaulin
+        run: cargo binstall cargo-tarpaulin@^0.23 --no-confirm
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: "--ignore-tests"
+        run: |
+          cargo tarpaulin --ignore-tests
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -163,7 +163,7 @@ jobs:
         run: cargo binstall cargo-tarpaulin@^0.23 --no-confirm
       - name: Run cargo-tarpaulin
         run: |
-          cargo tarpaulin --ignore-tests
+          cargo tarpaulin --ignore-tests -o Xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
このリポジトリで使われている[actions-rs/tarpaulin](https://github.com/actions-rs/tarpaulin)は2年以上メンテナンスが完全に放棄されており、最近は時々次のエラーで失敗するようになりました。

```console
Error: Cannot read property 'find' of undefined
```

たぶん[ここ](https://github.com/actions-rs/tarpaulin/blob/044a1e5bdace8dd2f727b1af63c1d9a1d3572068/src/config.ts#L81)とかじゃないかなと思っています。 #14 ではこれのために5回くらいre-run job failed jobsを押した気がします。

そのためactions-rs/tarpaulinを外してcargo-tarpaulinを直接ダウンロード&実行することを提案します。
([grcov](https://github.com/mozilla/grcov)とかに乗り換えるなり、coverage自体をやめるという選択肢もあるとは思います)
