### PR TITLE
ubuntu-18.04を除外

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -105,8 +105,8 @@ jobs:
           - os: macos-10.15
           - os: macos-11
           - os: macos-12
-          - os: ubuntu-18.04
           - os: ubuntu-20.04
+          - os: ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797


### PR DESCRIPTION
4/1からubuntu 18がGithub Actionsで動かなくなります。
単純に`ubuntu-22.04`に置き換えます。