### PR TITLE
`set-output` および `save-state` を使用しないようにする

### DIFF
--- a/.github/actions/auto_gen_bind_pr/action.yaml
+++ b/.github/actions/auto_gen_bind_pr/action.yaml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Extract branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
       id: extract_branch
     - name: Install cross compiler for aarch64
       if: inputs.triple == 'aarch64-unknown-linux-gnu'

--- a/.github/actions/auto_gen_bind_pr/action.yaml
+++ b/.github/actions/auto_gen_bind_pr/action.yaml
@@ -36,7 +36,7 @@ runs:
     - name: install triple
       run: rustup target add ${{ inputs.triple }}
       shell: bash
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
       with:
         # cargoのキャシュが原因でテストが失敗してることが考えられる場合はバージョン部分を変更する
         key: "v1-cargo-test-cache-${{ inputs.triple }}"

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -111,7 +111,6 @@ jobs:
             features: directml
           - os: windows-2022
             features: directml
-          - os: macos-10.15
           - os: macos-11
           - os: macos-12
           - os: ubuntu-20.04


### PR DESCRIPTION
## 内容

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ で周知されていたように、`set-output` や `save-state` が deprecated になっていて、他のリポジトリでは対応していました (cf. https://github.com/VOICEVOX/voicevox_core/pull/321) が、こちらのリポジトリではチェックが漏れていたところがあったので、上記機能を新しいものを使うように修正します。

`save-state` は直接は使用していませんが、`rust-cache@v1` 内で使われています。コアの方では過去に `v2` にアップデートしている (https://github.com/VOICEVOX/voicevox_core/pull/314) ので、そちらに合わせて `v2` を使用するようにしました。
